### PR TITLE
composer update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5085,16 +5085,16 @@
         },
         {
             "name": "revolution/atproto-lexicon-contracts",
-            "version": "1.0.32",
+            "version": "1.0.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/atproto-lexicon-contracts.git",
-                "reference": "55b62b02a445df4422778019a721ac34e2d003d5"
+                "reference": "68ae4da9ff0ba1c3d36e4c1471d090d746ddc58c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/atproto-lexicon-contracts/zipball/55b62b02a445df4422778019a721ac34e2d003d5",
-                "reference": "55b62b02a445df4422778019a721ac34e2d003d5",
+                "url": "https://api.github.com/repos/kawax/atproto-lexicon-contracts/zipball/68ae4da9ff0ba1c3d36e4c1471d090d746ddc58c",
+                "reference": "68ae4da9ff0ba1c3d36e4c1471d090d746ddc58c",
                 "shasum": ""
             },
             "require": {
@@ -5127,22 +5127,22 @@
                 "contracts"
             ],
             "support": {
-                "source": "https://github.com/kawax/atproto-lexicon-contracts/tree/1.0.32"
+                "source": "https://github.com/kawax/atproto-lexicon-contracts/tree/1.0.33"
             },
-            "time": "2024-11-22T03:43:35+00:00"
+            "time": "2024-11-23T03:48:23+00:00"
         },
         {
             "name": "revolution/laravel-bluesky",
-            "version": "0.13.7",
+            "version": "0.13.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/laravel-bluesky.git",
-                "reference": "5f293fc1eeaf6fdc99d2a12b6ed6670bd05a530b"
+                "reference": "161cf6aadbadd5cf127a6aaac03c1dcd11f7f10c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/laravel-bluesky/zipball/5f293fc1eeaf6fdc99d2a12b6ed6670bd05a530b",
-                "reference": "5f293fc1eeaf6fdc99d2a12b6ed6670bd05a530b",
+                "url": "https://api.github.com/repos/kawax/laravel-bluesky/zipball/161cf6aadbadd5cf127a6aaac03c1dcd11f7f10c",
+                "reference": "161cf6aadbadd5cf127a6aaac03c1dcd11f7f10c",
                 "shasum": ""
             },
             "require": {
@@ -5153,7 +5153,7 @@
                 "laravel/socialite": "^5.16",
                 "php": "^8.2",
                 "phpseclib/phpseclib": "^3.0",
-                "revolution/atproto-lexicon-contracts": "1.0.32",
+                "revolution/atproto-lexicon-contracts": "1.0.33",
                 "valtzu/guzzle-websocket-middleware": "^0.2.0"
             },
             "require-dev": {
@@ -5191,9 +5191,9 @@
                 "socialite"
             ],
             "support": {
-                "source": "https://github.com/kawax/laravel-bluesky/tree/0.13.7"
+                "source": "https://github.com/kawax/laravel-bluesky/tree/0.13.8"
             },
-            "time": "2024-11-22T13:09:58+00:00"
+            "time": "2024-11-23T09:22:06+00:00"
         },
         {
             "name": "revolution/laravel-nostr",


### PR DESCRIPTION
- Upgrading revolution/atproto-lexicon-contracts (1.0.32 => 1.0.33)
- Upgrading revolution/laravel-bluesky (0.13.7 => 0.13.8)