### PR TITLE
composer update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -709,82 +709,6 @@
             "time": "2023-10-06T06:47:41+00:00"
         },
         {
-            "name": "fgrosse/phpasn1",
-            "version": "v2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fgrosse/PHPASN1.git",
-                "reference": "42060ed45344789fb9f21f9f1864fc47b9e3507b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fgrosse/PHPASN1/zipball/42060ed45344789fb9f21f9f1864fc47b9e3507b",
-                "reference": "42060ed45344789fb9f21f9f1864fc47b9e3507b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "~2.0",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
-            },
-            "suggest": {
-                "ext-bcmath": "BCmath is the fallback extension for big integer calculations",
-                "ext-curl": "For loading OID information from the web if they have not bee defined statically",
-                "ext-gmp": "GMP is the preferred extension for big integer calculations",
-                "phpseclib/bcmath_compat": "BCmath polyfill for servers where neither GMP nor BCmath is available"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "FG\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Friedrich Große",
-                    "email": "friedrich.grosse@gmail.com",
-                    "homepage": "https://github.com/FGrosse",
-                    "role": "Author"
-                },
-                {
-                    "name": "All contributors",
-                    "homepage": "https://github.com/FGrosse/PHPASN1/contributors"
-                }
-            ],
-            "description": "A PHP Framework that allows you to encode and decode arbitrary ASN.1 structures using the ITU-T X.690 Encoding Rules.",
-            "homepage": "https://github.com/FGrosse/PHPASN1",
-            "keywords": [
-                "DER",
-                "asn.1",
-                "asn1",
-                "ber",
-                "binary",
-                "decoding",
-                "encoding",
-                "x.509",
-                "x.690",
-                "x509",
-                "x690"
-            ],
-            "support": {
-                "issues": "https://github.com/fgrosse/PHPASN1/issues",
-                "source": "https://github.com/fgrosse/PHPASN1/tree/v2.5.0"
-            },
-            "abandoned": true,
-            "time": "2022-12-19T11:08:26+00:00"
-        },
-        {
             "name": "firebase/php-jwt",
             "version": "v6.10.2",
             "source": {
@@ -2084,16 +2008,16 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                },
                 "laravel": {
-                    "providers": [
-                        "Laravel\\Vapor\\VaporServiceProvider"
-                    ],
                     "aliases": {
                         "Vapor": "Laravel\\Vapor\\Vapor"
-                    }
+                    },
+                    "providers": [
+                        "Laravel\\Vapor\\VaporServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2634,16 +2558,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v3.5.16",
+            "version": "v3.5.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "0b842088d716cadaf9d94fc4f096bc688db29d65"
+                "reference": "7bbf80d93db9b866776bf957ca6229364bca8d87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/0b842088d716cadaf9d94fc4f096bc688db29d65",
-                "reference": "0b842088d716cadaf9d94fc4f096bc688db29d65",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/7bbf80d93db9b866776bf957ca6229364bca8d87",
+                "reference": "7bbf80d93db9b866776bf957ca6229364bca8d87",
                 "shasum": ""
             },
             "require": {
@@ -2698,7 +2622,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v3.5.16"
+                "source": "https://github.com/livewire/livewire/tree/v3.5.17"
             },
             "funding": [
                 {
@@ -2706,7 +2630,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-02T15:57:58+00:00"
+            "time": "2024-12-06T13:41:21+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -5089,16 +5013,16 @@
         },
         {
             "name": "revolution/atproto-lexicon-contracts",
-            "version": "1.0.33",
+            "version": "1.0.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/atproto-lexicon-contracts.git",
-                "reference": "68ae4da9ff0ba1c3d36e4c1471d090d746ddc58c"
+                "reference": "0fbee436399637951b6dde8e9bad6603aa22f6ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/atproto-lexicon-contracts/zipball/68ae4da9ff0ba1c3d36e4c1471d090d746ddc58c",
-                "reference": "68ae4da9ff0ba1c3d36e4c1471d090d746ddc58c",
+                "url": "https://api.github.com/repos/kawax/atproto-lexicon-contracts/zipball/0fbee436399637951b6dde8e9bad6603aa22f6ee",
+                "reference": "0fbee436399637951b6dde8e9bad6603aa22f6ee",
                 "shasum": ""
             },
             "require": {
@@ -5131,22 +5055,22 @@
                 "contracts"
             ],
             "support": {
-                "source": "https://github.com/kawax/atproto-lexicon-contracts/tree/1.0.33"
+                "source": "https://github.com/kawax/atproto-lexicon-contracts/tree/1.0.35"
             },
-            "time": "2024-11-23T03:48:23+00:00"
+            "time": "2024-12-06T03:47:15+00:00"
         },
         {
             "name": "revolution/laravel-bluesky",
-            "version": "0.14.6",
+            "version": "0.14.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/laravel-bluesky.git",
-                "reference": "74074660264cc04feb89b0e14ff4940e86500782"
+                "reference": "800eaf03bc0799a42c4a80f67b16861dd08966a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/laravel-bluesky/zipball/74074660264cc04feb89b0e14ff4940e86500782",
-                "reference": "74074660264cc04feb89b0e14ff4940e86500782",
+                "url": "https://api.github.com/repos/kawax/laravel-bluesky/zipball/800eaf03bc0799a42c4a80f67b16861dd08966a6",
+                "reference": "800eaf03bc0799a42c4a80f67b16861dd08966a6",
                 "shasum": ""
             },
             "require": {
@@ -5157,7 +5081,7 @@
                 "laravel/socialite": "^5.16",
                 "php": "^8.2",
                 "phpseclib/phpseclib": "^3.0",
-                "revolution/atproto-lexicon-contracts": "1.0.33",
+                "revolution/atproto-lexicon-contracts": "1.0.35",
                 "valtzu/guzzle-websocket-middleware": "^0.2.0",
                 "yocto/yoclib-multibase": "^1.2"
             },
@@ -5197,22 +5121,22 @@
             ],
             "support": {
                 "issues": "https://github.com/kawax/laravel-bluesky/issues",
-                "source": "https://github.com/kawax/laravel-bluesky/tree/0.14.6"
+                "source": "https://github.com/kawax/laravel-bluesky/tree/0.14.7"
             },
-            "time": "2024-12-05T09:12:58+00:00"
+            "time": "2024-12-06T12:48:21+00:00"
         },
         {
             "name": "revolution/laravel-nostr",
-            "version": "0.6.12",
+            "version": "0.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/laravel-nostr.git",
-                "reference": "bdd67b348460ea9c11e8de707d813d7baccff9de"
+                "reference": "b44ace718ebaf3e6647ed2041806e161f1830349"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/laravel-nostr/zipball/bdd67b348460ea9c11e8de707d813d7baccff9de",
-                "reference": "bdd67b348460ea9c11e8de707d813d7baccff9de",
+                "url": "https://api.github.com/repos/kawax/laravel-nostr/zipball/b44ace718ebaf3e6647ed2041806e161f1830349",
+                "reference": "b44ace718ebaf3e6647ed2041806e161f1830349",
                 "shasum": ""
             },
             "require": {
@@ -5220,8 +5144,7 @@
                 "guzzlehttp/guzzle": "^7.8",
                 "illuminate/support": "^11.28",
                 "php": "^8.2",
-                "swentel/nostr-php": "^1.4",
-                "uma/phpecc": "^0.1.3",
+                "swentel/nostr-php": "^1.5.2",
                 "valtzu/guzzle-websocket-middleware": "^0.2.0"
             },
             "require-dev": {
@@ -5257,9 +5180,9 @@
             ],
             "support": {
                 "issues": "https://github.com/kawax/laravel-nostr/issues",
-                "source": "https://github.com/kawax/laravel-nostr/tree/0.6.12"
+                "source": "https://github.com/kawax/laravel-nostr/tree/0.6.13"
             },
-            "time": "2024-11-17T10:04:07+00:00"
+            "time": "2024-12-06T01:58:17+00:00"
         },
         {
             "name": "revolution/laravel-notification-discord-webhook",
@@ -6111,16 +6034,16 @@
         },
         {
             "name": "swentel/nostr-php",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nostrver-se/nostr-php.git",
-                "reference": "93091fae55173b8e0776199a8de08014441a15d4"
+                "reference": "cca30f99b07d6f2d1d645f670ac56d3c36b65bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nostrver-se/nostr-php/zipball/93091fae55173b8e0776199a8de08014441a15d4",
-                "reference": "93091fae55173b8e0776199a8de08014441a15d4",
+                "url": "https://api.github.com/repos/nostrver-se/nostr-php/zipball/cca30f99b07d6f2d1d645f670ac56d3c36b65bd1",
+                "reference": "cca30f99b07d6f2d1d645f670ac56d3c36b65bd1",
                 "shasum": ""
             },
             "require": {
@@ -6130,7 +6053,7 @@
                 "php": ">=8.1 <8.5",
                 "phrity/websocket": "^3.0",
                 "simplito/elliptic-php": "^1.0",
-                "uma/phpecc": "^0.1.3"
+                "uma/phpecc": "^0.2.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.51",
@@ -6172,9 +6095,9 @@
                 "chat": "https://t.me/nostr_php",
                 "issue": "https://github.com/swentel/nostr-php/issues",
                 "issues": "https://github.com/nostrver-se/nostr-php/issues",
-                "source": "https://github.com/nostrver-se/nostr-php/tree/1.5.1"
+                "source": "https://github.com/nostrver-se/nostr-php/tree/1.5.2"
             },
-            "time": "2024-11-24T22:06:24+00:00"
+            "time": "2024-12-05T09:03:53+00:00"
         },
         {
             "name": "symfony/clock",
@@ -8735,31 +8658,105 @@
             "time": "2020-03-10T17:25:19+00:00"
         },
         {
-            "name": "uma/phpecc",
-            "version": "v0.1.3",
+            "name": "uma/phpasn1",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/1ma/phpecc.git",
-                "reference": "a83dfa5fd6801fcc029364a555cec584d351c481"
+                "url": "https://github.com/1ma/PHPASN1.git",
+                "reference": "dd805d3157ddc90515ee13562a9bb241c68f4f88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/1ma/phpecc/zipball/a83dfa5fd6801fcc029364a555cec584d351c481",
-                "reference": "a83dfa5fd6801fcc029364a555cec584d351c481",
+                "url": "https://api.github.com/repos/1ma/PHPASN1/zipball/dd805d3157ddc90515ee13562a9bb241c68f4f88",
+                "reference": "dd805d3157ddc90515ee13562a9bb241c68f4f88",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-bcmath": "BCmath is the fallback extension for big integer calculations",
+                "ext-curl": "For loading OID information from the web if they have not bee defined statically",
+                "ext-gmp": "GMP is the preferred extension for big integer calculations",
+                "phpseclib/bcmath_compat": "BCmath polyfill for servers where neither GMP nor BCmath is available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "FG\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Friedrich Große",
+                    "email": "friedrich.grosse@gmail.com",
+                    "homepage": "https://github.com/FGrosse",
+                    "role": "Author"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/FGrosse/PHPASN1/contributors"
+                }
+            ],
+            "description": "A PHP Framework that allows you to encode and decode arbitrary ASN.1 structures using the ITU-T X.690 Encoding Rules.",
+            "homepage": "https://github.com/FGrosse/PHPASN1",
+            "keywords": [
+                "DER",
+                "asn.1",
+                "asn1",
+                "ber",
+                "binary",
+                "decoding",
+                "encoding",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "source": "https://github.com/1ma/PHPASN1/tree/v2.5.1"
+            },
+            "time": "2024-11-29T17:34:36+00:00"
+        },
+        {
+            "name": "uma/phpecc",
+            "version": "v0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/1ma/phpecc.git",
+                "reference": "8952716a7378a829b9ce50535e913f6592664173"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/1ma/phpecc/zipball/8952716a7378a829b9ce50535e913f6592664173",
+                "reference": "8952716a7378a829b9ce50535e913f6592664173",
                 "shasum": ""
             },
             "require": {
                 "ext-gmp": "*",
-                "fgrosse/phpasn1": "^2.0",
-                "php": "^8.0"
+                "php": "^8.0",
+                "uma/phpasn1": "^2.5.1"
             },
             "replace": {
                 "mdanter/ecc": "1.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0||^8.0||^9.0",
+                "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^2.0",
-                "symfony/yaml": "^2.6|^3.0"
+                "symfony/yaml": "^6.4 || ^7.0"
             },
             "type": "library",
             "autoload": {
@@ -8815,9 +8812,9 @@
                 "secp256r1"
             ],
             "support": {
-                "source": "https://github.com/1ma/phpecc/tree/v0.1.3"
+                "source": "https://github.com/1ma/phpecc/tree/v0.2.0"
             },
-            "time": "2024-02-27T15:58:47+00:00"
+            "time": "2024-11-29T17:59:36+00:00"
         },
         {
             "name": "valtzu/guzzle-websocket-middleware",
@@ -12122,16 +12119,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.4.4",
+            "version": "11.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f9ba7bd3c9f3ff54ec379d7a1c2e3f13fe0bbde4"
+                "reference": "0569902506a6c0878930b87ea79ec3b50ea563f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f9ba7bd3c9f3ff54ec379d7a1c2e3f13fe0bbde4",
-                "reference": "f9ba7bd3c9f3ff54ec379d7a1c2e3f13fe0bbde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0569902506a6c0878930b87ea79ec3b50ea563f7",
+                "reference": "0569902506a6c0878930b87ea79ec3b50ea563f7",
                 "shasum": ""
             },
             "require": {
@@ -12155,11 +12152,12 @@
                 "sebastian/comparator": "^6.2.1",
                 "sebastian/diff": "^6.0.2",
                 "sebastian/environment": "^7.2.0",
-                "sebastian/exporter": "^6.1.3",
+                "sebastian/exporter": "^6.3.0",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
                 "sebastian/type": "^5.1.0",
-                "sebastian/version": "^5.0.2"
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -12170,7 +12168,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.4-dev"
+                    "dev-main": "11.5-dev"
                 }
             },
             "autoload": {
@@ -12202,7 +12200,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.4.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.0"
             },
             "funding": [
                 {
@@ -12218,7 +12216,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-27T10:44:52+00:00"
+            "time": "2024-12-06T05:57:38+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -13142,6 +13140,58 @@
                 }
             ],
             "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "symfony/polyfill-php81",


### PR DESCRIPTION
- Removing fgrosse/phpasn1 (v2.5.0)
- Upgrading livewire/livewire (v3.5.16 => v3.5.17)
- Upgrading phpunit/phpunit (11.4.4 => 11.5.0)
- Upgrading revolution/atproto-lexicon-contracts (1.0.33 => 1.0.35)
- Upgrading revolution/laravel-bluesky (0.14.6 => 0.14.7)
- Upgrading revolution/laravel-nostr (0.6.12 => 0.6.13)
- Locking staabm/side-effects-detector (1.0.5)
- Upgrading swentel/nostr-php (1.5.1 => 1.5.2)
- Locking uma/phpasn1 (v2.5.1)
- Upgrading uma/phpecc (v0.1.3 => v0.2.0)