### PR TITLE
composer update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.336.11",
+            "version": "3.336.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "442039c766a82f06ecfecb0ac2c610d6aaba228d"
+                "reference": "a173ab3af8d9186d266e4937d8254597f36a9e15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/442039c766a82f06ecfecb0ac2c610d6aaba228d",
-                "reference": "442039c766a82f06ecfecb0ac2c610d6aaba228d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a173ab3af8d9186d266e4937d8254597f36a9e15",
+                "reference": "a173ab3af8d9186d266e4937d8254597f36a9e15",
                 "shasum": ""
             },
             "require": {
@@ -154,9 +154,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.336.11"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.336.12"
             },
-            "time": "2025-01-08T19:06:59+00:00"
+            "time": "2025-01-09T19:04:34+00:00"
         },
         {
             "name": "bitwasp/bech32",
@@ -4115,16 +4115,16 @@
         },
         {
             "name": "phrity/net-stream",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirn-se/phrity-net-stream.git",
-                "reference": "b44451b35a94942792d9857dfbad89f816d0b6ef"
+                "reference": "e6ace997168bebcce814c95cd5c78c78663ae49a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirn-se/phrity-net-stream/zipball/b44451b35a94942792d9857dfbad89f816d0b6ef",
-                "reference": "b44451b35a94942792d9857dfbad89f816d0b6ef",
+                "url": "https://api.github.com/repos/sirn-se/phrity-net-stream/zipball/e6ace997168bebcce814c95cd5c78c78663ae49a",
+                "reference": "e6ace997168bebcce814c95cd5c78c78663ae49a",
                 "shasum": ""
             },
             "require": {
@@ -4169,9 +4169,9 @@
             ],
             "support": {
                 "issues": "https://github.com/sirn-se/phrity-net-stream/issues",
-                "source": "https://github.com/sirn-se/phrity-net-stream/tree/2.1.1"
+                "source": "https://github.com/sirn-se/phrity-net-stream/tree/2.1.2"
             },
-            "time": "2024-12-07T15:38:18+00:00"
+            "time": "2025-01-09T08:07:34+00:00"
         },
         {
             "name": "phrity/net-uri",
@@ -5110,16 +5110,16 @@
         },
         {
             "name": "revolution/atproto-lexicon-contracts",
-            "version": "1.0.40",
+            "version": "1.0.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/atproto-lexicon-contracts.git",
-                "reference": "adf79a37316cbb986a40c49df0f3a347e0d78c75"
+                "reference": "43a6cb804ffa9a9e52c6bdb10afd680cf26c8144"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/atproto-lexicon-contracts/zipball/adf79a37316cbb986a40c49df0f3a347e0d78c75",
-                "reference": "adf79a37316cbb986a40c49df0f3a347e0d78c75",
+                "url": "https://api.github.com/repos/kawax/atproto-lexicon-contracts/zipball/43a6cb804ffa9a9e52c6bdb10afd680cf26c8144",
+                "reference": "43a6cb804ffa9a9e52c6bdb10afd680cf26c8144",
                 "shasum": ""
             },
             "require": {
@@ -5153,22 +5153,22 @@
                 "contracts"
             ],
             "support": {
-                "source": "https://github.com/kawax/atproto-lexicon-contracts/tree/1.0.40"
+                "source": "https://github.com/kawax/atproto-lexicon-contracts/tree/1.0.41"
             },
-            "time": "2024-12-28T03:37:37+00:00"
+            "time": "2025-01-03T04:05:28+00:00"
         },
         {
             "name": "revolution/laravel-bluesky",
-            "version": "0.16.3",
+            "version": "0.16.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kawax/laravel-bluesky.git",
-                "reference": "90e7d14c81a74b041fe6ab9cc2cc60ce48295b0e"
+                "reference": "97fabb22c065a76a28b4cfc4381e750f27f91a6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kawax/laravel-bluesky/zipball/90e7d14c81a74b041fe6ab9cc2cc60ce48295b0e",
-                "reference": "90e7d14c81a74b041fe6ab9cc2cc60ce48295b0e",
+                "url": "https://api.github.com/repos/kawax/laravel-bluesky/zipball/97fabb22c065a76a28b4cfc4381e750f27f91a6d",
+                "reference": "97fabb22c065a76a28b4cfc4381e750f27f91a6d",
                 "shasum": ""
             },
             "require": {
@@ -5179,7 +5179,7 @@
                 "laravel/socialite": "^5.16",
                 "php": "^8.2",
                 "phpseclib/phpseclib": "^3.0",
-                "revolution/atproto-lexicon-contracts": "1.0.40",
+                "revolution/atproto-lexicon-contracts": "1.0.41",
                 "yocto/yoclib-multibase": "^1.2"
             },
             "require-dev": {
@@ -5230,9 +5230,9 @@
             ],
             "support": {
                 "issues": "https://github.com/kawax/laravel-bluesky/issues",
-                "source": "https://github.com/kawax/laravel-bluesky/tree/0.16.3"
+                "source": "https://github.com/kawax/laravel-bluesky/tree/0.16.4"
             },
-            "time": "2025-01-05T05:32:05+00:00"
+            "time": "2025-01-09T09:22:40+00:00"
         },
         {
             "name": "revolution/laravel-nostr",


### PR DESCRIPTION
- Upgrading aws/aws-sdk-php (3.336.11 => 3.336.12)
- Upgrading phrity/net-stream (2.1.1 => 2.1.2)
- Upgrading revolution/atproto-lexicon-contracts (1.0.40 => 1.0.41)
- Upgrading revolution/laravel-bluesky (0.16.3 => 0.16.4)